### PR TITLE
Fix how prior reports are linked for adding manual statuses where no data is present

### DIFF
--- a/app.py
+++ b/app.py
@@ -1161,7 +1161,11 @@ def add_status(item_id):
     if prior_report is not None:
         previous_report_has_ticket = prior_report.ref is not None
 
-    if previous_report_has_ticket or category == StatusType.BROKEN:
+    if prior_report is None or previous_report_has_ticket or category == StatusType.BROKEN:
+        # make a new report if:
+        #   - the last one had a ticket number (manual status is unlikely to have one, so this is prob a different incident/should be tracked separately)
+        #   - the ticket is for something broken (new report flow)
+        #   - there is no prior report 
         current_report = Report()
         db.session.add(current_report)
         db.session.flush()

--- a/app.py
+++ b/app.py
@@ -1156,8 +1156,10 @@ def add_status(item_id):
 
     prior_report = get_item_report(item_id)
     current_report = None
+    previous_report_has_ticket = None
 
-    previous_report_has_ticket = prior_report.ref is not None
+    if prior_report is not None:
+        previous_report_has_ticket = prior_report.ref is not None
 
     if previous_report_has_ticket or category == StatusType.BROKEN:
         current_report = Report()


### PR DESCRIPTION
fixes crash in #41 

the logic was firstly not correctly handling a nonexistent "previous report"  scenario when looking up a previous reports ref (ticket) number

secondly it was not creating a new report to hold the incoming status when there was no previous one