### PR TITLE
allow admin mode to fall back to the old style "is the site in debug mode" checks when proper auth is not configured

### DIFF
--- a/app.py
+++ b/app.py
@@ -834,8 +834,8 @@ def home():
 def about():
     return render_template("about.html",
         pageTitle="About CampusPulse Access",
-        authsession=get_logged_in_user(),
-        is_admin = check_for_admin_role(get_logged_in_user_id())
+        authsession=get_logged_in_user(debug_mode=app.debug),
+        is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug))
     )
 
 
@@ -843,16 +843,16 @@ def about():
 def fmsreport():
     return render_template("fmsreport.html",
         pageTitle="Reporting to the RIT Service Center",
-        authsession=get_logged_in_user(),
-        is_admin = check_for_admin_role(get_logged_in_user_id())
+        authsession=get_logged_in_user(debug_mode=app.debug),
+        is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug))
     )
 
 
 @app.route("/map")
 def map_page():
     return render_template("map.html",
-        authsession=get_logged_in_user(),
-        is_admin = check_for_admin_role(get_logged_in_user_id())
+        authsession=get_logged_in_user(debug_mode=app.debug),
+        is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug))
         )
 
 
@@ -864,8 +864,8 @@ def catalog():
         if page is None:
             return render_template(
             "catalog.html",
-            authsession=get_logged_in_user(),
-            is_admin = check_for_admin_role(get_logged_in_user_id()),
+            authsession=get_logged_in_user(debug_mode=app.debug),
+            is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug)),
             q=query,
             page=1,
             accessPoints=getAccessPointsPaginated(0),
@@ -875,16 +875,16 @@ def catalog():
             page = int(page)
             return render_template(
                 "paginated.html",
-                authsession=get_logged_in_user(),
-                is_admin = check_for_admin_role(get_logged_in_user_id()),
+                authsession=get_logged_in_user(debug_mode=app.debug),
+                is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug)),
                 page=(page+1),
                 murals=getAccessPointsPaginated(page)
             )
     else:
         return render_template(
             "filtered.html",
-            authsession=get_logged_in_user(),
-            is_admin = check_for_admin_role(get_logged_in_user_id()),
+            authsession=get_logged_in_user(debug_mode=app.debug),
+            is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug)),
             pageTitle=f"Query - {query}",
             subHeading="Search Query",
             q=query,
@@ -917,10 +917,10 @@ def access_point(id):
     if not checkAccessPointExists(id):
         return render_template("404.html"), 404
     
-    is_admin = check_for_admin_role(get_logged_in_user_id())
+    is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug))
     return render_template(
         "access_point.html", 
-        authsession=get_logged_in_user(),
+        authsession=get_logged_in_user(debug_mode=app.debug),
         is_admin=is_admin,
         accessPointDetails=getAccessPoint(id, is_admin=is_admin)
         
@@ -999,7 +999,7 @@ def requires_admin(f):
     """
     @wraps(f)
     def decorated(*args, **kwargs):
-        user = get_logged_in_user_id()
+        user = get_logged_in_user_id(debug_mode=app.debug)
         is_admin = check_for_admin_role(user)
 
         if user is None:
@@ -1153,7 +1153,7 @@ def add_status(item_id):
     status_text = request.form.get("status")
     note_text = request.form.get("note")
     category = StatusType(int(request.form.get("category")))
-    author = get_logged_in_user_info()
+    author = get_logged_in_user_info(debug_mode=app.debug)
     author_identifier = f" - manually added by {author['name']} ({author['sub']}) via web UI"
 
     note_text += author_identifier
@@ -1509,8 +1509,8 @@ def admin():
     """
     return render_template(
         "admin.html",
-        authsession=get_logged_in_user(),
-        is_admin = check_for_admin_role(get_logged_in_user_id()),
+        authsession=get_logged_in_user(debug_mode=app.debug),
+        is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug)),
         tags=getAllTags(),
         formData=formFieldData(),
         accessPoints=getAllAccessPoints(),

--- a/app.py
+++ b/app.py
@@ -52,11 +52,11 @@ import pandas as pd
 import json_log_formatter
 from pathlib import Path
 from dotenv import load_dotenv
-from helpers import floor_to_integer, RoomNumber, integer_to_floor, MapLocation, ServiceNowStatus, ServiceNowUpdateType, save_user_details, check_for_admin_role, get_logged_in_user_id, get_logged_in_user, get_logged_in_user_info
+from helpers import floor_to_integer, RoomNumber, integer_to_floor, MapLocation, ServiceNowStatus, ServiceNowUpdateType
 from urllib.parse import quote_plus, urlencode
 from authlib.integrations.flask_client import OAuth
 from openai import OpenAI
-from auth0service import is_auth_configured
+from auth0service import is_auth_configured, save_user_details, check_for_admin_role, get_logged_in_user_id, get_logged_in_user, get_logged_in_user_info
 
 
 app = Flask(__name__)

--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ from helpers import floor_to_integer, RoomNumber, integer_to_floor, MapLocation,
 from urllib.parse import quote_plus, urlencode
 from authlib.integrations.flask_client import OAuth
 from openai import OpenAI
+from auth0service import is_auth_configured
 
 
 app = Flask(__name__)
@@ -89,12 +90,7 @@ logging.info("Starting up...")
 git_cmd = ["git", "rev-parse", "--short", "HEAD"]
 app.config["GIT_REVISION"] = subprocess.check_output(git_cmd).decode("utf-8").rstrip()
 
-auth_configured = not None in [
-    os.environ.get("AUTH0_DOMAIN"),
-    os.environ.get("CPACCESS_SECRET_KEY"),
-    os.environ.get("AUTH0_CLIENT_ID"),
-    os.environ.get("AUTH0_CLIENT_SECRET")
-]
+auth_configured = is_auth_configured()
 
 if auth_configured:
     # Auth Setup

--- a/app.py
+++ b/app.py
@@ -110,6 +110,10 @@ if is_auth_configured():
 
 else:
     logging.info("Auth configuration not available due to missing variables. Ensure all of AUTH0_DOMAIN, CPACCESS_SECRET_KEY, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET are present")
+    logging.info("To use admin mode features without configuring, run in debug mode.")
+
+    if app.debug:
+        logging.info("You are currently in debug mode")
 
 
 # Make sure your OPENAI_API_KEY is in your environment variables

--- a/app.py
+++ b/app.py
@@ -1492,6 +1492,8 @@ def edit(id):
     if checkAccessPointExists(id):
         return render_template(
             "edit.html",
+            authsession=get_logged_in_user(debug_mode=app.debug),
+            is_admin = check_for_admin_role(get_logged_in_user_id(debug_mode=app.debug)),
             accessPointDetails=getAccessPoint(id),
             accessPointFeedback=getAccessPointFeedback(id),
             tags=getAllTags(),

--- a/app.py
+++ b/app.py
@@ -90,9 +90,7 @@ logging.info("Starting up...")
 git_cmd = ["git", "rev-parse", "--short", "HEAD"]
 app.config["GIT_REVISION"] = subprocess.check_output(git_cmd).decode("utf-8").rstrip()
 
-auth_configured = is_auth_configured()
-
-if auth_configured:
+if is_auth_configured():
     # Auth Setup
     app.secret_key = os.environ.get("CPACCESS_SECRET_KEY")
 
@@ -932,7 +930,7 @@ def access_point(id):
 #
 ########################
 
-if auth_configured:
+if is_auth_configured():
     @app.route("/callback", methods=["GET", "POST"])
     def callback():
         token = oauth.auth0.authorize_access_token()

--- a/auth0service.py
+++ b/auth0service.py
@@ -1,0 +1,12 @@
+import os 
+
+def is_auth_configured() -> bool:
+	"""Whether auth is configured to run in production mode
+	"""
+	return not None in [
+		os.environ.get("AUTH0_DOMAIN"),
+		os.environ.get("CPACCESS_SECRET_KEY"),
+		os.environ.get("AUTH0_CLIENT_ID"),
+		os.environ.get("AUTH0_CLIENT_SECRET")
+	]
+

--- a/auth0service.py
+++ b/auth0service.py
@@ -1,5 +1,10 @@
 import os 
 
+DEBUG_MODE_USERINFO = {
+	"name": "DEVELOPER",
+	"sub": "debug:1234567890"
+}
+
 def is_auth_configured() -> bool:
 	"""Whether auth is configured to run in production mode
 	"""

--- a/auth0service.py
+++ b/auth0service.py
@@ -1,4 +1,5 @@
 import os 
+import requests
 
 DEBUG_MODE_USERINFO = {
 	"name": "DEVELOPER",
@@ -14,4 +15,85 @@ def is_auth_configured() -> bool:
 		os.environ.get("AUTH0_CLIENT_ID"),
 		os.environ.get("AUTH0_CLIENT_SECRET")
 	]
+
+
+def get_auth0_user_roles(user_id):
+
+    auth0_domain = os.environ.get("AUTH0_DOMAIN")
+    client_id = os.environ.get("AUTH0_CLIENT_ID")
+    client_secret = os.environ.get("AUTH0_CLIENT_SECRET")
+        
+    # Step 1: Get Management API token
+    token_url = f"https://{auth0_domain}/oauth/token"
+    token_payload = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "audience": f"https://{auth0_domain}/api/v2/",
+        "grant_type": "client_credentials"
+    }
+    
+    token_response = requests.post(token_url, json=token_payload)
+    if token_response.status_code != 200:
+        raise Exception(f"Error fetching token: {token_response.text}")
+    
+    access_token = token_response.json()["access_token"]
+
+    # Step 2: Query user roles
+    roles_url = f"https://{auth0_domain}/api/v2/users/{user_id}/roles"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {access_token}"
+    }
+    
+    roles_response = requests.get(roles_url, headers=headers)
+    if roles_response.status_code != 200:
+        raise Exception(f"Error fetching user roles: {roles_response.text}")
+
+    roles = roles_response.json()
+    return roles  # List of role objects
+
+
+def check_for_admin_role(user_id):
+    if user_id is None:
+        return False
+
+    # this function is always passed the result of get_logged_in_user_id()
+    # (yeah theyre badly structured i know)
+    # and that function gets given a dev mode value, so it wouldnt make sense to have to pass it in here too. Therefore we basically check whether the user id matches
+    # the hardcoded developer user id
+    if (not is_auth_configured()) and user_id == DEBUG_MODE_USERINFO.get("sub"):
+        return True
+
+    roles_json = get_auth0_user_roles(user_id)
+    # current_app.logger.info(roles_json)
+    for r in roles_json:
+        rolename = r["name"].lower()
+        if 'admin' in rolename:
+            return True
+    return False
+
+def get_logged_in_user(debug_mode=False):
+    if is_auth_configured():
+        return session.get("user")
+    elif debug_mode:
+        return {
+            "userinfo": DEBUG_MODE_USERINFO
+        }
+
+def get_logged_in_user_info(debug_mode=False):
+    user = get_logged_in_user(debug_mode=debug_mode)
+    userinfo = None
+    if user is not None:
+        userinfo = user.get("userinfo")
+    return userinfo
+
+def get_logged_in_user_id(debug_mode=False):
+    userinfo = get_logged_in_user_info(debug_mode=debug_mode)
+    if userinfo is not None:
+        return userinfo.get("sub")
+
+def save_user_details(token):
+    # verify_token(token["id_token"], auth0_domain, api_identifier)
+    session["user"] = token
+
 

--- a/helpers.py
+++ b/helpers.py
@@ -4,6 +4,8 @@ from dateutil import parser
 from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
+from auth0service import is_auth_configured, DEBUG_MODE_USERINFO
+
 from flask import session
 import requests
 import os
@@ -232,18 +234,23 @@ def check_for_admin_role(user_id):
             return True
     return False
 
-def get_logged_in_user():
-    return session.get("user")
+def get_logged_in_user(debug_mode=False):
+    if is_auth_configured():
+        return session.get("user")
+    elif debug_mode:
+        return {
+            "userinfo": DEBUG_MODE_USERINFO
+        }
 
-def get_logged_in_user_info():
-    user = get_logged_in_user()
+def get_logged_in_user_info(debug_mode=False):
+    user = get_logged_in_user(debug_mode=debug_mode)
     userinfo = None
     if user is not None:
         userinfo = user.get("userinfo")
     return userinfo
 
-def get_logged_in_user_id():
-    userinfo = get_logged_in_user_info()
+def get_logged_in_user_id(debug_mode=False):
+    userinfo = get_logged_in_user_info(debug_mode=debug_mode)
     if userinfo is not None:
         return userinfo.get("sub")
 

--- a/helpers.py
+++ b/helpers.py
@@ -225,7 +225,14 @@ def get_auth0_user_roles(user_id):
 def check_for_admin_role(user_id):
     if user_id is None:
         return False
-    
+
+    # this function is always passed the result of get_logged_in_user_id()
+    # (yeah theyre badly structured i know)
+    # and that function gets given a dev mode value, so it wouldnt make sense to have to pass it in here too. Therefore we basically check whether the user id matches
+    # the hardcoded developer user id
+    if (not is_auth_configured()) and user_id == DEBUG_MODE_USERINFO.get("sub"):
+        return True
+
     roles_json = get_auth0_user_roles(user_id)
     # current_app.logger.info(roles_json)
     for r in roles_json:

--- a/helpers.py
+++ b/helpers.py
@@ -4,8 +4,6 @@ from dateutil import parser
 from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
-from auth0service import is_auth_configured, DEBUG_MODE_USERINFO
-
 from flask import session
 import requests
 import os
@@ -183,86 +181,4 @@ class ServiceNowStatus:
 		if new_comment:
 			comment, timestamp = cls.commentFromBody(body)
 		return cls(timestamp, status_type, ref, comment)
-
-
-
-def get_auth0_user_roles(user_id):
-
-    auth0_domain = os.environ.get("AUTH0_DOMAIN")
-    client_id = os.environ.get("AUTH0_CLIENT_ID")
-    client_secret = os.environ.get("AUTH0_CLIENT_SECRET")
-        
-    # Step 1: Get Management API token
-    token_url = f"https://{auth0_domain}/oauth/token"
-    token_payload = {
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "audience": f"https://{auth0_domain}/api/v2/",
-        "grant_type": "client_credentials"
-    }
-    
-    token_response = requests.post(token_url, json=token_payload)
-    if token_response.status_code != 200:
-        raise Exception(f"Error fetching token: {token_response.text}")
-    
-    access_token = token_response.json()["access_token"]
-
-    # Step 2: Query user roles
-    roles_url = f"https://{auth0_domain}/api/v2/users/{user_id}/roles"
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {access_token}"
-    }
-    
-    roles_response = requests.get(roles_url, headers=headers)
-    if roles_response.status_code != 200:
-        raise Exception(f"Error fetching user roles: {roles_response.text}")
-
-    roles = roles_response.json()
-    return roles  # List of role objects
-
-
-def check_for_admin_role(user_id):
-    if user_id is None:
-        return False
-
-    # this function is always passed the result of get_logged_in_user_id()
-    # (yeah theyre badly structured i know)
-    # and that function gets given a dev mode value, so it wouldnt make sense to have to pass it in here too. Therefore we basically check whether the user id matches
-    # the hardcoded developer user id
-    if (not is_auth_configured()) and user_id == DEBUG_MODE_USERINFO.get("sub"):
-        return True
-
-    roles_json = get_auth0_user_roles(user_id)
-    # current_app.logger.info(roles_json)
-    for r in roles_json:
-        rolename = r["name"].lower()
-        if 'admin' in rolename:
-            return True
-    return False
-
-def get_logged_in_user(debug_mode=False):
-    if is_auth_configured():
-        return session.get("user")
-    elif debug_mode:
-        return {
-            "userinfo": DEBUG_MODE_USERINFO
-        }
-
-def get_logged_in_user_info(debug_mode=False):
-    user = get_logged_in_user(debug_mode=debug_mode)
-    userinfo = None
-    if user is not None:
-        userinfo = user.get("userinfo")
-    return userinfo
-
-def get_logged_in_user_id(debug_mode=False):
-    userinfo = get_logged_in_user_info(debug_mode=debug_mode)
-    if userinfo is not None:
-        return userinfo.get("sub")
-
-def save_user_details(token):
-    # verify_token(token["id_token"], auth0_domain, api_identifier)
-    session["user"] = token
-
 


### PR DESCRIPTION
This PR allows the admin features of the site to work when a) auth0 variables are not configured, AND b) the site is run in debug mode (should be the default when using the `uv run` command in the README


fixes #18 
