### PR TITLE
Fix discord links

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -51,7 +51,7 @@ About - CampusPulse Access
                 <div class="col-md-6 pt-4 h-100">
                     <h2>Future Plans</h2>
                     <div class="text-start">
-                        <p>As an open source project and a capstone project, we are hopeful that CampusPulse Access will continue improving long after its founders are gone. There are opportunities for students across multiple majors to contribute to this site whether for capstones, portfolios, or fun. If you would like to hear about future development opportunities, please <a href="https://discord.gg/2d75fdPZE3">join our Discord</a> or contact us via email. </p>
+                        <p>As an open source project and a capstone project, we are hopeful that CampusPulse Access will continue improving long after its founders are gone. There are opportunities for students across multiple majors to contribute to this site whether for capstones, portfolios, or fun. If you would like to hear about future development opportunities, please <a href="https://discord.access.campuspulse.app/">join our Discord</a> or contact us via email. </p>
                     </div>
                 </div>
                 <div class="col-md-6 pt-4 h-100">

--- a/templates/header.html
+++ b/templates/header.html
@@ -142,7 +142,7 @@
                         <path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm8.93 4.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM8 5.5a1 1 0 1 0 0-2 1 1 0 0 0 0 2" />
                     </svg> </svg>
                 </a> -->
-                <a class="nav-link" href="https://discord.gg/THxBajHs8U" target="_blank" rel="noindex nofollow">
+                <a class="nav-link" href="https://discord.access.campuspulse.app/" target="_blank" rel="noindex nofollow">
                     <img alt="Discord logo" src="/static/images/discord-fontawesome.svg" style="width: 30px;">
                 </a>
                 <a class="nav-link" href="https://github.com/CampusPulse/access-directory" target="_blank">


### PR DESCRIPTION
Closes #47 
I updated the two discord links, one directly in the header as the discord button, and the other on the about page as a link.
Before: discord.gg/2d75fdPZE3
After: discord.access.campuspulse.app/
